### PR TITLE
[Issue#34] Using redis for session Handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,11 @@
             <artifactId>commons-io</artifactId>
             <version>${commons-io-version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>net.debasishg</groupId>
+            <artifactId>redisclient${scala.minor-version}</artifactId>
+            <version>3.1</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/donoroncall/server/connectors/MysqlConnector.java
+++ b/src/main/java/com/donoroncall/server/connectors/MysqlConnector.java
@@ -15,7 +15,7 @@ import java.sql.SQLException;
 /**
  * Created by vishnu on 20/1/16.
  */
-public class MysqlClient {
+public class MysqlConnector {
 
     private Logger LOG = LoggerFactory.getLogger(this.getClass());
     public String dbc;
@@ -23,7 +23,7 @@ public class MysqlClient {
     private Connection connection;
 
     @Inject
-    public MysqlClient(Config config) throws SQLException {
+    public MysqlConnector(Config config) throws SQLException {
         String host = config.getString("server.mysql.host");
         String port = config.getString("server.mysql.port");
         String user = config.getString("server.mysql.user");

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -7,7 +7,7 @@ server:{
     interface:"0.0.0.0"
   }
   security:{
-    sessionHandler:"InMemorySessionHandler"
+    sessionHandler:"InMemorySessionHandler" // RedisSessionHandler or InMemorySessionHandler
   }
   mysql: {
     host = "localhost"
@@ -15,5 +15,15 @@ server:{
     user = "root"
     password = "sam"
     db = "donor_on_call"
+  }
+  redis:{
+    host = "localhost"
+    port = 16379
+    databases=[
+      {
+        name="session"
+        number=1
+      }
+    ]
   }
 }

--- a/src/main/scala/com/donoroncall/server/BootStrapServer.scala
+++ b/src/main/scala/com/donoroncall/server/BootStrapServer.scala
@@ -1,6 +1,6 @@
 package com.donoroncall.server
 
-import com.donoroncall.server.connectors.MysqlClient
+import com.donoroncall.server.connectors.MysqlConnector
 import com.donoroncall.server.di.ServerDiModule
 import com.donoroncall.server.rest.ServerInterface
 import com.google.inject.Guice
@@ -22,7 +22,7 @@ object BootStrapServer {
 
   val serverInterface = injector.getInstance(classOf[ServerInterface])
 
-  val mysqlClient = injector.getInstance(classOf[MysqlClient])
+  val mysqlClient = injector.getInstance(classOf[MysqlConnector])
 
   def main(args: Array[String]) {
     serverInterface.startServer

--- a/src/main/scala/com/donoroncall/server/connectors/RedisConnector.scala
+++ b/src/main/scala/com/donoroncall/server/connectors/RedisConnector.scala
@@ -14,7 +14,7 @@ class RedisConnector @Inject()(config: Config) {
     f.getString("name") -> new RedisClient(
       config.getString("server.redis.host"),
       config.getString("server.redis.port").toInt,
-      f.getInt("database"))
+      f.getInt("number"))
   ).toMap
 
   def getClient(database: String): RedisClient = clientsMap.getOrElse(database, null)

--- a/src/main/scala/com/donoroncall/server/connectors/RedisConnector.scala
+++ b/src/main/scala/com/donoroncall/server/connectors/RedisConnector.scala
@@ -1,0 +1,27 @@
+package com.donoroncall.server.connectors
+
+import com.google.inject.Inject
+import com.redis.RedisClient
+import com.typesafe.config.Config
+import scala.collection.JavaConversions._
+
+/**
+  * Created by vishnu on 18/4/16.
+  */
+class RedisConnector @Inject()(config: Config) {
+
+  private val clientsMap = config.getConfigList("server.redis.databases").map(f =>
+    f.getString("name") -> new RedisClient(
+      config.getString("server.redis.host"),
+      config.getString("server.redis.port").toInt,
+      f.getInt("database"))
+  ).toMap
+
+  def getClient(database: String): RedisClient = clientsMap.getOrElse(database, null)
+}
+
+object RedisConnector {
+
+
+
+}

--- a/src/main/scala/com/donoroncall/server/di/ServerDiModule.scala
+++ b/src/main/scala/com/donoroncall/server/di/ServerDiModule.scala
@@ -1,8 +1,8 @@
 package com.donoroncall.server.di
 
-import com.donoroncall.server.connectors.MysqlClient
+import com.donoroncall.server.connectors.MysqlConnector
 import com.donoroncall.server.rest.ServerInterface
-import com.donoroncall.server.rest.controllers.authentication.{InMemorySessionHandler, SessionHandler}
+import com.donoroncall.server.rest.controllers.authentication.session.{RedisSessionHandler, InMemorySessionHandler, SessionHandler}
 import com.donoroncall.server.rest.undertow.UndertowApiServer
 import com.google.inject.{AbstractModule, Binder, Module}
 import com.typesafe.config.Config
@@ -15,10 +15,11 @@ class ServerDiModule(config: Config) extends AbstractModule with ScalaModule {
   override def configure(): Unit = {
 
     bind[Config].toInstance(config)
-    bind[MysqlClient].asInstanceOf[Singleton]
+    bind[MysqlConnector].asInstanceOf[Singleton]
 
     config.getString("server.security.sessionHandler") match {
       case "InMemorySessionHandler" => bind[SessionHandler].to[InMemorySessionHandler].asInstanceOf[Singleton]
+      case "RedisSessionHandler" => bind[SessionHandler].to[RedisSessionHandler].asInstanceOf[Singleton]
       case _ => bind[SessionHandler].to[InMemorySessionHandler].asInstanceOf[Singleton]
     }
     bind[ServerInterface].to[UndertowApiServer].asInstanceOf[Singleton]

--- a/src/main/scala/com/donoroncall/server/di/ServerDiModule.scala
+++ b/src/main/scala/com/donoroncall/server/di/ServerDiModule.scala
@@ -1,6 +1,6 @@
 package com.donoroncall.server.di
 
-import com.donoroncall.server.connectors.MysqlConnector
+import com.donoroncall.server.connectors.{RedisConnector, MysqlConnector}
 import com.donoroncall.server.rest.ServerInterface
 import com.donoroncall.server.rest.controllers.authentication.session.{RedisSessionHandler, InMemorySessionHandler, SessionHandler}
 import com.donoroncall.server.rest.undertow.UndertowApiServer
@@ -18,8 +18,14 @@ class ServerDiModule(config: Config) extends AbstractModule with ScalaModule {
     bind[MysqlConnector].asInstanceOf[Singleton]
 
     config.getString("server.security.sessionHandler") match {
+
       case "InMemorySessionHandler" => bind[SessionHandler].to[InMemorySessionHandler].asInstanceOf[Singleton]
-      case "RedisSessionHandler" => bind[SessionHandler].to[RedisSessionHandler].asInstanceOf[Singleton]
+
+      case "RedisSessionHandler" => {
+        bind[RedisConnector].asInstanceOf[Singleton]
+        bind[SessionHandler].to[RedisSessionHandler].asInstanceOf[Singleton]
+      }
+
       case _ => bind[SessionHandler].to[InMemorySessionHandler].asInstanceOf[Singleton]
     }
     bind[ServerInterface].to[UndertowApiServer].asInstanceOf[Singleton]

--- a/src/main/scala/com/donoroncall/server/rest/controllers/authentication/AuthenticationController.scala
+++ b/src/main/scala/com/donoroncall/server/rest/controllers/authentication/AuthenticationController.scala
@@ -2,6 +2,7 @@ package com.donoroncall.server.rest.controllers.authentication
 
 import java.util
 import com.donoroncall.server.BootStrapServer.mysqlClient
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.donoroncall.server.utils.Security
 import com.google.inject.Inject
 

--- a/src/main/scala/com/donoroncall/server/rest/controllers/authentication/EditProfileController.scala
+++ b/src/main/scala/com/donoroncall/server/rest/controllers/authentication/EditProfileController.scala
@@ -3,6 +3,7 @@ package com.donoroncall.server.rest.controllers.authentication
 import java.security.MessageDigest
 
 import com.donoroncall.server.BootStrapServer.mysqlClient
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.donoroncall.server.utils.SqlUtils
 import com.google.inject.Inject
 

--- a/src/main/scala/com/donoroncall/server/rest/controllers/authentication/NotificationController.scala
+++ b/src/main/scala/com/donoroncall/server/rest/controllers/authentication/NotificationController.scala
@@ -3,6 +3,7 @@ package com.donoroncall.server.rest.controllers.authentication
 import java.security.MessageDigest
 
 import com.donoroncall.server.BootStrapServer.mysqlClient
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.google.inject.Inject
 
 

--- a/src/main/scala/com/donoroncall/server/rest/controllers/authentication/session/InMemorySessionHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/controllers/authentication/session/InMemorySessionHandler.scala
@@ -1,9 +1,9 @@
-package com.donoroncall.server.rest.controllers.authentication
+package com.donoroncall.server.rest.controllers.authentication.session
 
 import com.donoroncall.server.utils.TokenGenerator
 import com.google.inject.Inject
 import com.typesafe.config.Config
-import org.slf4j.{LoggerFactory, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 import spray.json.{JsNumber, JsObject}
 
 /**

--- a/src/main/scala/com/donoroncall/server/rest/controllers/authentication/session/RedisSessionHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/controllers/authentication/session/RedisSessionHandler.scala
@@ -1,0 +1,23 @@
+package com.donoroncall.server.rest.controllers.authentication.session
+
+import com.redis.RedisClient
+import spray.json.JsObject
+
+/**
+  * Created by vishnu on 18/4/16.
+  */
+class RedisSessionHandler extends SessionHandler {
+  override def getUserIdForSession(sessionToken: String): Long = ???
+
+  override def clearAllSessions: Boolean = ???
+
+  override def createSessionTokenForUser(userId: Long): String = ???
+
+  override def getAllSessions: JsObject = ???
+
+  override def clearSessionToken(token: String): Unit = ???
+}
+
+object RedisSessionHandler {
+
+}

--- a/src/main/scala/com/donoroncall/server/rest/controllers/authentication/session/RedisSessionHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/controllers/authentication/session/RedisSessionHandler.scala
@@ -1,23 +1,77 @@
 package com.donoroncall.server.rest.controllers.authentication.session
 
-import com.redis.RedisClient
-import spray.json.JsObject
+import com.donoroncall.server.connectors.RedisConnector
+import com.donoroncall.server.utils.TokenGenerator
+import com.google.inject.Inject
+import org.slf4j.{LoggerFactory, Logger}
+import spray.json.{JsString, JsObject}
 
 /**
   * Created by vishnu on 18/4/16.
   */
-class RedisSessionHandler extends SessionHandler {
-  override def getUserIdForSession(sessionToken: String): Long = ???
+class RedisSessionHandler @Inject()(redisConnector: RedisConnector) extends SessionHandler {
 
-  override def clearAllSessions: Boolean = ???
+  private val LOG: Logger = LoggerFactory.getLogger(this.getClass)
 
-  override def createSessionTokenForUser(userId: Long): String = ???
+  private val redis = redisConnector.getClient("session")
 
-  override def getAllSessions: JsObject = ???
+  private val SESSION_TTL_SECONDS: Int = 24 * 60 * 60
 
-  override def clearSessionToken(token: String): Unit = ???
-}
+  override def getUserIdForSession(sessionToken: String): Long = {
+    LOG.debug("gettingUserFor Session " + sessionToken)
+    try {
+      val sessions = redis.get(sessionToken)
+      if (sessions.isEmpty)
+        0
+      else {
+        redis.expire(sessionToken, SESSION_TTL_SECONDS)
+        sessions.head.toLong
+      }
+    } catch {
+      case e: Exception => LOG.debug("Error While Fetching Session : " + sessionToken, e)
+        0
+    }
+  }
 
-object RedisSessionHandler {
+  override def clearAllSessions: Boolean = {
+    try {
+      redis.flushdb
+      true
+    } catch {
+      case e: Exception => LOG.debug("Error While Flushing the Session", e)
+        false
+    }
+  }
 
+  override def createSessionTokenForUser(userId: Long): String = {
+    try {
+      val token = TokenGenerator.generateSHAToken(userId.toString)
+      redis.set(token, userId)
+      redis.expire(token, SESSION_TTL_SECONDS)
+      token
+    } catch {
+      case e: Exception => LOG.debug("Error While Creating the Session ", e)
+        null
+    }
+  }
+
+  override def getAllSessions: JsObject = try {
+    val t: Map[String, String] = redis.hgetall() match {
+      case Some(s) => s
+      case _ => Map()
+    }
+    JsObject(t.map(i => i._1 -> JsString(i._2)))
+  } catch {
+    case e: Exception => LOG.debug("Error While Getting the Session Values", e)
+      JsObject()
+  }
+
+  override def clearSessionToken(token: String): Unit = {
+    try {
+      redis.del(token)
+    } catch {
+      case e: Exception => LOG.debug("Error While Deleting the Session " + token, e)
+    }
+
+  }
 }

--- a/src/main/scala/com/donoroncall/server/rest/controllers/authentication/session/SessionHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/controllers/authentication/session/SessionHandler.scala
@@ -1,4 +1,4 @@
-package com.donoroncall.server.rest.controllers.authentication
+package com.donoroncall.server.rest.controllers.authentication.session
 
 import com.donoroncall.server.models.User
 import spray.json.JsObject

--- a/src/main/scala/com/donoroncall/server/rest/undertow/handlers/admin/AdminApiHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/undertow/handlers/admin/AdminApiHandler.scala
@@ -1,6 +1,6 @@
 package com.donoroncall.server.rest.undertow.handlers.admin
 
-import com.donoroncall.server.rest.controllers.authentication.SessionHandler
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.google.inject.Inject
 import io.undertow.server.{HttpServerExchange, HttpHandler}
 import org.apache.commons.io.IOUtils

--- a/src/main/scala/com/donoroncall/server/rest/undertow/handlers/authentication/LoginApiHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/undertow/handlers/authentication/LoginApiHandler.scala
@@ -1,6 +1,6 @@
 package com.donoroncall.server.rest.undertow.handlers.authentication
 
-import com.donoroncall.server.rest.controllers.authentication.{SessionHandler, AuthenticationController}
+import com.donoroncall.server.rest.controllers.authentication.AuthenticationController
 import com.google.inject.Inject
 import io.undertow.server.{HttpHandler, HttpServerExchange}
 import io.undertow.util.HttpString

--- a/src/main/scala/com/donoroncall/server/rest/undertow/handlers/authentication/LogoutApiHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/undertow/handlers/authentication/LogoutApiHandler.scala
@@ -1,6 +1,7 @@
 package com.donoroncall.server.rest.undertow.handlers.authentication
 
-import com.donoroncall.server.rest.controllers.authentication.{AuthenticationController, SessionHandler}
+import com.donoroncall.server.rest.controllers.authentication.AuthenticationController
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.google.inject.Inject
 import io.undertow.server.{HttpHandler, HttpServerExchange}
 import io.undertow.util.HttpString

--- a/src/main/scala/com/donoroncall/server/rest/undertow/handlers/bloodRequest/GetBloodRequestHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/undertow/handlers/bloodRequest/GetBloodRequestHandler.scala
@@ -1,7 +1,7 @@
 package com.donoroncall.server.rest.undertow.handlers.bloodRequest
 
 import com.donoroncall.server.models.{BloodRequest, User}
-import com.donoroncall.server.rest.controllers.authentication.SessionHandler
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.google.inject.Inject
 import io.undertow.server.{HttpHandler, HttpServerExchange}
 import org.apache.commons.io.IOUtils

--- a/src/main/scala/com/donoroncall/server/rest/undertow/handlers/bloodRequest/RegisterBloodRequestHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/undertow/handlers/bloodRequest/RegisterBloodRequestHandler.scala
@@ -1,7 +1,7 @@
 package com.donoroncall.server.rest.undertow.handlers.bloodRequest
 
 import com.donoroncall.server.models.{User, BloodRequest}
-import com.donoroncall.server.rest.controllers.authentication.SessionHandler
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.google.inject.Inject
 import io.undertow.server.{HttpServerExchange, HttpHandler}
 import org.apache.commons.io.IOUtils

--- a/src/main/scala/com/donoroncall/server/rest/undertow/handlers/donationRecord/GetDonationRecordHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/undertow/handlers/donationRecord/GetDonationRecordHandler.scala
@@ -1,7 +1,7 @@
 package com.donoroncall.server.rest.undertow.handlers.donationRecord
 
 import com.donoroncall.server.models.{DonationRecord, BloodRequest, User}
-import com.donoroncall.server.rest.controllers.authentication.SessionHandler
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.google.inject.Inject
 import io.undertow.server.{HttpHandler, HttpServerExchange}
 import org.apache.commons.io.IOUtils

--- a/src/main/scala/com/donoroncall/server/rest/undertow/handlers/donationRecord/RegisterDonationRecordHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/undertow/handlers/donationRecord/RegisterDonationRecordHandler.scala
@@ -1,7 +1,7 @@
 package com.donoroncall.server.rest.undertow.handlers.donationRecord
 
 import com.donoroncall.server.models.{DonationRecord, BloodRequest, User}
-import com.donoroncall.server.rest.controllers.authentication.SessionHandler
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.google.inject.Inject
 import io.undertow.server.{HttpHandler, HttpServerExchange}
 import org.apache.commons.io.IOUtils

--- a/src/main/scala/com/donoroncall/server/rest/undertow/handlers/user/GetUserHandler.scala
+++ b/src/main/scala/com/donoroncall/server/rest/undertow/handlers/user/GetUserHandler.scala
@@ -1,6 +1,6 @@
 package com.donoroncall.server.rest.undertow.handlers.user
 
-import com.donoroncall.server.rest.controllers.authentication.SessionHandler
+import com.donoroncall.server.rest.controllers.authentication.session.SessionHandler
 import com.google.inject.Inject
 import io.undertow.server.{HttpServerExchange, HttpHandler}
 import org.apache.commons.io.IOUtils


### PR DESCRIPTION
#34  To use Redis for Session Storage

Change the following properties in the application.conf

Session Handler Property  `sessionHandler:"RedisSessionHandler"`

And the Redis Server Configuration in the redis configuration Block

```
redis:{
    host = "localhost"
    port = 16379
    databases=[
      {
        name="session"
        number=1
      }
    ]
  }
```
#39 By default the TTL is set to 24 hours after the api has been last accessed
